### PR TITLE
Incremented the version to 3.6

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -18,7 +18,7 @@ var configuration = Argument("configuration", "Debug");
 // SET PACKAGE VERSION
 //////////////////////////////////////////////////////////////////////
 
-var version = "3.5.0";
+var version = "3.6.0";
 
 var dbgSuffix = configuration == "Debug" ? "-dbg" : "";
 var packageVersion = version + dbgSuffix;

--- a/src/extension/Properties/AssemblyInfo.cs
+++ b/src/extension/Properties/AssemblyInfo.cs
@@ -23,5 +23,5 @@ using System.Runtime.InteropServices;
 [assembly: Guid("6e520555-91a4-427d-8416-b0689e535cc9")]
 
 // Set the version of the extension
-[assembly: AssemblyVersion("3.5.0.0")]
-[assembly: AssemblyFileVersion("3.5.0.0")]
+[assembly: AssemblyVersion("3.6.0.0")]
+[assembly: AssemblyFileVersion("3.6.0.0")]


### PR DESCRIPTION
I am wondering if this is the correct procedure for extensions. Is it likely that future releases will be hotfixes and I should only increment to 3.5.1?
