### PR TITLE
Refactor so that magic strings are all in one place

### DIFF
--- a/nunit-project-loader.sln
+++ b/nunit-project-loader.sln
@@ -10,6 +10,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{3B28CF0C-D613-4971-9D8F-00C960C656E2}"
 	ProjectSection(SolutionItems) = preProject
 		build.cake = build.cake
+		nunit-project-loader.nuspec = nunit-project-loader.nuspec
 	EndProjectSection
 EndProject
 Global


### PR DESCRIPTION
This came out of an error in the docs, where the casing of a few attributes was incorrect. In researching the problem, it was very hard to figure out what all the values should be, since they were distributed as strings all through the code.

The PR simply adds consts at the top of the NUnitProject.cs file for all the strings used and does a small bit of refactoring in the code.