### PR TITLE
Disable testing under .NET Core for now

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -3,8 +3,6 @@
 #tool nuget:?package=GitReleaseManager&version=0.17.0
 #tool nuget:?package=NUnit.ConsoleRunner&version=3.17.0
 #tool nuget:?package=NUnit.ConsoleRunner&version=3.15.5
-#tool nuget:?package=NUnit.ConsoleRunner.NetCore&Version=3.17.0
-#tool nuget:?package=NUnit.ConsoleRunner.NetCore&Version=3.15.5
 
 ////////////////////////////////////////////////////////////////////
 // CONSTANTS
@@ -16,6 +14,7 @@ const string CHOCO_ID = "nunit-extension-nunit-project-loader";
 const string GITHUB_OWNER = "nunit";
 const string GITHUB_REPO = "nunit-project-loader";
 const string DEFAULT_CONFIGURATION = "Release";
+static readonly string[] CONSOLE_VERSIONS_FOR_PACKAGE_TESTS = new string[] { "3.17.0", "3.15.5" };
 const string CONSOLE_VERSION_FOR_UNIT_TESTS = "3.17.0";
 
 // Load scripts after defining constants
@@ -214,7 +213,7 @@ PackageTest[] PackageTests = new PackageTest[]
 	{
 		Description = "Project with one assembly, all tests pass",
 		Arguments = "PassingAssembly.nunit",
-		TestConsoleVersions = new string[] { "3.17.0", "3.15.5", "NetCore.3.17.0", "NetCore.3.15.5" },
+		TestConsoleVersions =  CONSOLE_VERSIONS_FOR_PACKAGE_TESTS,
 		ExpectedResult = new ExpectedResult("Passed")
 		{
 			Total = 4,
@@ -230,7 +229,7 @@ PackageTest[] PackageTests = new PackageTest[]
 	{
 		Description = "Project with one assembly, some failures",
 		Arguments = "FailingAssembly.nunit",
-		TestConsoleVersions = new string[] { "3.17.0", "3.15.5", "NetCore.3.17.0", "NetCore.3.15.5" },
+		TestConsoleVersions =  CONSOLE_VERSIONS_FOR_PACKAGE_TESTS,
 		ExpectedResult = new ExpectedResult("Failed")
 		{
 			Total = 9,
@@ -246,7 +245,7 @@ PackageTest[] PackageTests = new PackageTest[]
 	{
 		Description = "Project with both assemblies",
 		Arguments = "BothAssemblies.nunit",
-		TestConsoleVersions = new string[] { "3.17.0", "3.15.5", "NetCore.3.17.0", "NetCore.3.15.5" },
+		TestConsoleVersions =  CONSOLE_VERSIONS_FOR_PACKAGE_TESTS,
 		ExpectedResult = new ExpectedResult("Failed")
 		{
 			Total = 13,

--- a/cake/package-tests.cake
+++ b/cake/package-tests.cake
@@ -39,7 +39,7 @@ public abstract class PackageTester
 
 		foreach (var packageTest in packageTests)
 		{
-			var resultFile = _parameters.OutputDirectory + DEFAULT_TEST_RESULT_FILE;
+			var resultFile = _parameters.ProjectDirectory + DEFAULT_TEST_RESULT_FILE;
 
 			foreach (var consoleVersion in packageTest.TestConsoleVersions)
 			{
@@ -85,8 +85,8 @@ public abstract class PackageTester
 	private void RunConsoleTest(string consoleVersion, string arguments)
     {
 		string runnerDir = _parameters.ToolsDirectory + $"NUnit.ConsoleRunner.{consoleVersion}/tools/";
-		if (consoleVersion.StartsWith("NetCore."))
-			runnerDir += "net6.0/";
+		//if (consoleVersion.StartsWith("NetCore."))
+		//	runnerDir += "net6.0/any/";
 		string runner = runnerDir + "nunit3-console.exe";
 		bool isNetCoreRunner = consoleVersion.StartsWith("NetCore.");
 
@@ -98,9 +98,9 @@ public abstract class PackageTester
 				writer.WriteLine("../../nunit-extension-*/tools/");
 		}
 
-		if (isNetCoreRunner)
-			_context.StartProcess("dotnet", $"\"{runner}\" {arguments}");
-		else
+		//if (isNetCoreRunner)
+		//	_context.StartProcess("dotnet", $"\"{runner}\" {arguments}");
+		//else
 			_context.StartProcess(runner, arguments);
 		// We don't check the error code because we know that
 		// mock-assembly returns -4 due to a bad fixture.


### PR DESCRIPTION
We don't currently include a .NET Core or .NET Standard version of the extension in our packages, so it can't work yet.