### PR TITLE
Make package multi-targeted

### DIFF
--- a/BothAssembliesNetCore.nunit
+++ b/BothAssembliesNetCore.nunit
@@ -1,0 +1,7 @@
+<NUnitProject>
+  <Settings processModel="Default" domainUsage="Default" />
+  <Config name="Release" appbase="bin/Release">
+    <assembly path="net6.0/test-lib-1.dll" />
+    <assembly path="net6.0/test-lib-2.dll" />
+  </Config>
+</NUnitProject>

--- a/FailingAssemblyNetCore.nunit
+++ b/FailingAssemblyNetCore.nunit
@@ -1,0 +1,6 @@
+<NUnitProject>
+  <Settings processModel="Default" domainUsage="Default" />
+  <Config name="Release" appbase="bin/Release">
+    <assembly path="net6.0/test-lib-2.dll" />
+  </Config>
+</NUnitProject>

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,4 +1,4 @@
-next-version: 3.7.2
+next-version: 3.8.0
 mode: ContinuousDelivery
 legacy-semver-padding: 5
 build-metadata-padding: 5

--- a/PassingAssemblyNetCore.nunit
+++ b/PassingAssemblyNetCore.nunit
@@ -1,0 +1,6 @@
+<NUnitProject>
+  <Settings processModel="Default" domainUsage="Default" />
+  <Config name="Release" appbase="bin/Release">
+    <assembly path="net6.0/test-lib-1.dll" />
+  </Config>
+</NUnitProject>

--- a/cake/package-tests.cake
+++ b/cake/package-tests.cake
@@ -84,22 +84,28 @@ public abstract class PackageTester
 
 	private void RunConsoleTest(string consoleVersion, string arguments)
     {
-		string runnerDir = _parameters.ToolsDirectory + $"NUnit.ConsoleRunner.{consoleVersion}/tools/";
-		//if (consoleVersion.StartsWith("NetCore."))
-		//	runnerDir += "net6.0/any/";
-		string runner = runnerDir + "nunit3-console.exe";
 		bool isNetCoreRunner = consoleVersion.StartsWith("NetCore.");
+
+		string runnerDir = _parameters.ToolsDirectory + $"NUnit.ConsoleRunner.{consoleVersion}/tools/";
+		if (isNetCoreRunner) runnerDir += "net6.0/";
+
+		var runner = runnerDir + "nunit3-console.exe";
 
 		if (InstallDirectory.EndsWith(CHOCO_ID + "/"))
 		{
-			// We are using nuget packages for the runner, so add an extra
-			// addins file to allow detecting chocolatey packages
+			// We are using nuget packages for the runner, so it won't normally recognize
+			// chocolatey packages. We add an extra addins file for that purpose.
 			using (var writer = new StreamWriter(runnerDir + "/choco.engine.addins"))
+			{
 				writer.WriteLine("../../nunit-extension-*/tools/");
+				writer.WriteLine("../../nunit-extension-*/tools/*/");
+				writer.WriteLine("../../../nunit-extension-*/tools/");
+				writer.WriteLine("../../../nunit-extension-*/tools/*/");
+			}
 		}
-
+		
 		//if (isNetCoreRunner)
-		//	_context.StartProcess("dotnet", $"\"{runner}\" {arguments}");
+		//	_context.StartProcess("dotnet", $"\"{runnerDir}nunit3-console.exe\" {arguments}");
 		//else
 			_context.StartProcess(runner, arguments);
 		// We don't check the error code because we know that

--- a/cake/packaging.cake
+++ b/cake/packaging.cake
@@ -30,8 +30,11 @@ public void BuildNuGetPackage(BuildParameters parameters)
 		var content = new List<NuSpecContent>();
 		content.Add(new NuSpecContent { Source = parameters.ProjectDirectory + "LICENSE.txt" });
 		content.Add(new NuSpecContent { Source = parameters.ProjectDirectory + "CHANGES.md" });
-		content.Add(new NuSpecContent { Source = parameters.OutputDirectory + "net20/nunit-project-loader.dll", Target = "tools" });
-		content.Add(new NuSpecContent { Source = parameters.OutputDirectory + "net20/nunit.engine.api.dll", Target = "tools" });
+		content.Add(new NuSpecContent { Source = parameters.ProjectDirectory + "nunit-project-loader.addins", Target = "tools" });
+		content.Add(new NuSpecContent { Source = parameters.OutputDirectory + "net20/nunit-project-loader.dll", Target = "tools/net20" });
+		content.Add(new NuSpecContent { Source = parameters.OutputDirectory + "net20/nunit.engine.api.dll", Target = "tools/net20" });
+		content.Add(new NuSpecContent { Source = parameters.OutputDirectory + "net6.0/nunit-project-loader.dll", Target = "tools/net6.0" });
+		content.Add(new NuSpecContent { Source = parameters.OutputDirectory + "net6.0/nunit.engine.api.dll", Target = "tools/net6.0" });
 
 	NuGetPack(
 		new NuGetPackSettings()
@@ -69,8 +72,11 @@ public void BuildChocolateyPackage(BuildParameters parameters)
     content.Add(new ChocolateyNuSpecContent { Source = parameters.ProjectDirectory + "LICENSE.txt", Target = "tools" });
     content.Add(new ChocolateyNuSpecContent { Source = parameters.ProjectDirectory + "CHANGES.md", Target = "tools" });
     content.Add(new ChocolateyNuSpecContent { Source = parameters.ProjectDirectory + "VERIFICATION.txt", Target = "tools" });
-	content.Add(new ChocolateyNuSpecContent { Source = parameters.OutputDirectory + "net20/nunit-project-loader.dll", Target = "tools" });
-	content.Add(new ChocolateyNuSpecContent { Source = parameters.OutputDirectory + "net20/nunit.engine.api.dll", Target = "tools" });
+	content.Add(new ChocolateyNuSpecContent { Source = parameters.ProjectDirectory + "nunit-project-loader.addins", Target = "tools" });
+	content.Add(new ChocolateyNuSpecContent { Source = parameters.OutputDirectory + "net20/nunit-project-loader.dll", Target = "tools/net20" });
+	content.Add(new ChocolateyNuSpecContent { Source = parameters.OutputDirectory + "net20/nunit.engine.api.dll", Target = "tools/net20" });
+	content.Add(new ChocolateyNuSpecContent { Source = parameters.OutputDirectory + "net6.0/nunit-project-loader.dll", Target = "tools/net6.0" });
+	content.Add(new ChocolateyNuSpecContent { Source = parameters.OutputDirectory + "net6.0/nunit.engine.api.dll", Target = "tools/net6.0" });
 
     ChocolateyPack(
 		new ChocolateyPackSettings()

--- a/nunit-project-loader.addins
+++ b/nunit-project-loader.addins
@@ -1,0 +1,4 @@
+# Inclusion of this addins file allows older versions of the console runner
+# to locate extensions in subdirectories of the tools directory.
+net20/nunit-project-loader.dll
+net60/nunit-project-loader.dll

--- a/nunit-project-loader.sln
+++ b/nunit-project-loader.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30320.27
+# Visual Studio Version 17
+VisualStudioVersion = 17.8.34525.116
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "nunit-project-loader", "src\extension\nunit-project-loader.csproj", "{26270E99-C60E-4816-8342-D6BBCFFD4809}"
 EndProject
@@ -20,6 +20,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		GitReleaseManager.yaml = GitReleaseManager.yaml
 		GitVersion.yml = GitVersion.yml
 		LICENSE.txt = LICENSE.txt
+		nunit-project-loader.addins = nunit-project-loader.addins
 		nunit-project-loader.nuspec = nunit-project-loader.nuspec
 		PassingAssembly.nunit = PassingAssembly.nunit
 		README.md = README.md

--- a/src/extension/nunit-project-loader.csproj
+++ b/src/extension/nunit-project-loader.csproj
@@ -2,13 +2,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <!-- If adding/updating TargetFrameworks, also update build.cake -->
-    <TargetFrameworks>net20;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net20;net6.0</TargetFrameworks>
     <Configurations>Debug;Release</Configurations>
     <OutputType>Library</OutputType>
     <RootNamespace>NUnit.Engine.Services.ProjectLoaders</RootNamespace>
     <AssemblyName>nunit-project-loader</AssemblyName>
     <OutputPath>..\..\bin\$(Configuration)\</OutputPath>
-
+	  <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>

--- a/src/test-lib-1/test-lib-1.csproj
+++ b/src/test-lib-1/test-lib-1.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <!-- If adding/updating TargetFrameworks, also update build.cake -->
-    <TargetFramework>net20</TargetFramework>
+    <TargetFrameworks>net20;net6.0</TargetFrameworks>
     <Configurations>Debug;Release</Configurations>
     <OutputType>Library</OutputType>
     <RootNamespace>TestLib1</RootNamespace>

--- a/src/test-lib-2/test-lib-2.csproj
+++ b/src/test-lib-2/test-lib-2.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <!-- If adding/updating TargetFrameworks, also update build.cake -->
-    <TargetFramework>net20</TargetFramework>
+    <TargetFrameworks>net20;net6.0</TargetFrameworks>
     <Configurations>Debug;Release</Configurations>
     <OutputType>Library</OutputType>
     <RootNamespace>TestLib2</RootNamespace>

--- a/src/tests/nunit-project-loader.tests.csproj
+++ b/src/tests/nunit-project-loader.tests.csproj
@@ -1,30 +1,33 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <!-- If adding/updating TargetFrameworks, also update build.cake -->
-    <!-- Even though we don't support running tests build for netcoreapp2.1 yet, we still build for it -->
-    <TargetFrameworks>net20;netcoreapp2.1</TargetFrameworks>
-    <Configurations>Debug;Release</Configurations>
-    <RootNamespace>NUnit.Engine.Tests</RootNamespace>
-    <AssemblyName>nunit-project-loader.tests</AssemblyName>
-
-    <OutputPath>..\..\bin\$(Configuration)\</OutputPath>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-  </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="nunit.engine.api" Version="3.11.1" />
-    <!-- This is the newest NUnit that support .NET Framework 2.0 -->
-    <PackageReference Include="NUnit" Version="3.11.0" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\extension\nunit-project-loader.csproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <EmbeddedResource Include="resources\NUnitProject.nunit" />
-    <EmbeddedResource Include="resources\NUnitProject_ComplexSettings.nunit" />
-    <EmbeddedResource Include="resources\NUnitProject_EmptyConfigs.nunit" />
-    <EmbeddedResource Include="resources\NUnitProject_EmptyProject.nunit" />
-    <EmbeddedResource Include="resources\NUnitProject_ManualBinPath.nunit" />
-    <EmbeddedResource Include="resources\NUnitProject_XmlDecl.nunit" />
-  </ItemGroup>
+    
+	<PropertyGroup>
+        <!-- If adding/updating TargetFrameworks, also update build.cake -->
+        <!-- Even though we don't support running tests build for netcoreapp2.1 yet, we still build for it -->
+        <TargetFrameworks>net462;net6.0</TargetFrameworks>
+        <Configurations>Debug;Release</Configurations>
+        <RootNamespace>NUnit.Engine.Tests</RootNamespace>
+        <AssemblyName>nunit-project-loader.tests</AssemblyName>
+        <OutputPath>..\..\bin\$(Configuration)\</OutputPath>
+        <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    </PropertyGroup>
+	
+	<ItemGroup>
+		<PackageReference Include="nunit.engine.api" Version="3.11.1" />
+		<PackageReference Include="NUnit" Version="3.14.0" />
+	</ItemGroup>
+  
+	<ItemGroup>
+        <ProjectReference Include="..\extension\nunit-project-loader.csproj" />
+    </ItemGroup>
+  
+	<ItemGroup>
+        <EmbeddedResource Include="resources\NUnitProject.nunit" />
+        <EmbeddedResource Include="resources\NUnitProject_ComplexSettings.nunit" />
+        <EmbeddedResource Include="resources\NUnitProject_EmptyConfigs.nunit" />
+        <EmbeddedResource Include="resources\NUnitProject_EmptyProject.nunit" />
+        <EmbeddedResource Include="resources\NUnitProject_ManualBinPath.nunit" />
+        <EmbeddedResource Include="resources\NUnitProject_XmlDecl.nunit" />
+    </ItemGroup>
+	
 </Project>


### PR DESCRIPTION
Fixes #61 , allowing the extension to work for earlier versions of the console runner as well as the latest 3.x development version. It also works for the `NUnit.ConsoleRunner.NetCore`.